### PR TITLE
bugfix/16 sensors not working after upgrading to 20

### DIFF
--- a/custom_components/swedish_calendar/sensor.py
+++ b/custom_components/swedish_calendar/sensor.py
@@ -51,7 +51,6 @@ class SwedishCalendarSensor(CoordinatorEntity):
         self._default_value = default_value
         self._attribution = attribution
         self.entity_id = 'sensor.swedish_calendar_{}'.format(sensor_type)
-        self._handle_coordinator_update()  # Set initial state
 
     @property
     def name(self):
@@ -89,6 +88,9 @@ class SwedishCalendarSensor(CoordinatorEntity):
         """Return hidden if it should not be visible in GUI"""
         return self._state is None or self._state == ""
 
+    async def async_added_to_hass(self):
+        self._handle_coordinator_update()  # Set initial state
+
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
@@ -97,4 +99,6 @@ class SwedishCalendarSensor(CoordinatorEntity):
             state = swedish_calendar.get_value_by_attribute(self.state_key)
             if isinstance(state, list):
                 state = ",".join(state)
+            elif isinstance(state, bool):
+                state = 'Ja' if state else 'Nej'
             self._state = state

--- a/custom_components/swedish_calendar/types.py
+++ b/custom_components/swedish_calendar/types.py
@@ -12,7 +12,7 @@ class SwedishCalendar:
         if attr != 'themes':
             return getattr(self.api_data, attr)
         else:
-            return self.themes.themes
+            return self.themes.themes if self.themes is not None else None
 
 
 class ApiData:

--- a/custom_components/swedish_calendar/types.py
+++ b/custom_components/swedish_calendar/types.py
@@ -22,7 +22,7 @@ class ApiData:
         self.work_free_day: bool = self._to_bool(json_data["arbetsfri dag"])
         self.red_day: bool = self._to_bool(json_data["röd dag"])
         self.week: int = int(json_data["vecka"])
-        self.day_of_week_index: int = int(json_data["dag i vecka"]) - 1  # data is 1-indexed adjust
+        self.day_of_week_index: int = int(json_data["dag i vecka"])
         self.name_day: List[str] = json_data["namnsdag"]
         self.reason_for_flagging: Optional[str] = self._to_optional(json_data, "flaggdag")
         self.eve: Optional[str] = self._to_optional(json_data, 'helgdagsafton')


### PR DESCRIPTION
Bug is solved by checking if themes exist before trying to access value. The commit didn't seem to have been pushed so was missed in 2.0.0 release.

Also updated some minor thins:
* Fetch initial data in async_added_to_hass instead of in constructor
* Revert day_of_week_index to be 1-index