### PR TITLE
#18: Initialize listeners to receive data updates

### DIFF
--- a/custom_components/swedish_calendar/sensor.py
+++ b/custom_components/swedish_calendar/sensor.py
@@ -51,6 +51,7 @@ class SwedishCalendarSensor(CoordinatorEntity):
         self._default_value = default_value
         self._attribution = attribution
         self.entity_id = 'sensor.swedish_calendar_{}'.format(sensor_type)
+        self._state = None
 
     @property
     def name(self):
@@ -89,7 +90,8 @@ class SwedishCalendarSensor(CoordinatorEntity):
         return self._state is None or self._state == ""
 
     async def async_added_to_hass(self):
-        self._handle_coordinator_update()  # Set initial state
+        await super().async_added_to_hass() # Set up coordintaor listener
+        self._handle_coordinator_update()   # Set initial state
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -102,3 +104,4 @@ class SwedishCalendarSensor(CoordinatorEntity):
             elif isinstance(state, bool):
                 state = 'Ja' if state else 'Nej'
             self._state = state
+            super()._handle_coordinator_update()

--- a/custom_components/swedish_calendar/utils.py
+++ b/custom_components/swedish_calendar/utils.py
@@ -1,4 +1,4 @@
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta
 
 
 class DateUtils:
@@ -10,3 +10,10 @@ class DateUtils:
     @staticmethod
     def in_range(isodate: str, start: date, end: date) -> bool:
         return start <= date.fromisoformat(isodate) <= end
+
+    @staticmethod
+    def seconds_until_midnight(now: datetime) -> int:
+        tomorrow = date.today() + timedelta(days=1)
+        midnight = datetime.combine(tomorrow, datetime.min.time())
+        now = datetime.now()
+        return (midnight - now).seconds + 1


### PR DESCRIPTION
* Sensor entity calls `await super().async_added_to_hass()` to set up coordinator listeners and receive updates
* Coordinator polls every midnight instead of every hour, since every hour can cause inconsistent behaviour such as  updating 23:59, then updating 00:59 etc..