### PR TITLE
Feature/13 opt in to download special themes file

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ HomeAssistant 2022.5.1 or later
 2. Download the contents (the raw files, NOT as HTML) of the files from **custom_components/swedish_calendar** to the new directory
 
 ## Configuration
-| Name               | Required | Default | Description                                                                                                                                                                            |
-|--------------------|----------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| exclude            | no       | *empty list* | All sensor types are tracked by default, this config lets you specify which sensor types that you **don't** want to track. For full list of options, see [Supported sensor types](#supported-sensor-types). |
-| special_themes_dir | no       | *empty string* | The path to the directory where you downloaded the specialThemes.json to. See [Special themes config](#special-themes).                                                                |
-| calendar_config    | no       | *empty object* | The calendar config, if you want sensors to be shown in the HomeAssistant Calendar. See [Calendar configuration](#calendar).                                                           |
+| Name            | Required | Default        | Description                                                                                                                                                                                                 |
+|-----------------|----------|----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| exclude         | no       | *empty list*   | All sensor types are tracked by default, this config lets you specify which sensor types that you **don't** want to track. For full list of options, see [Supported sensor types](#supported-sensor-types). |
+| special_themes  | no       | *empty object* | The special themes config, see [Special themes config](#special-themes).                                                                                                                                    |
+| calendar_config | no       | *empty object* | The calendar config, if you want sensors to be shown in the HomeAssistant Calendar. See [Calendar configuration](#calendar).                                                                                |
 
 ### Minimal configuration
 ~~~~yaml
@@ -64,18 +64,33 @@ swedish_calendar:
 ~~~~
 
 ### Special themes
-If you would like to include data about special themes/days, like 🍪 Kanelbullens dag 🍪, you can configure the directory where you downloaded the `specialThemes.json`
+Special themes include data about common celebrations in Sweden, like 🍪 Kanelbullens dag or 🦢 Mårtensafton.
 
+| Name             | Required | Default        | Description                                                                                                                                                                               |
+|------------------|----------|----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| dir              | no       | *empty string* | The path to the directory where you downloaded the specialThemes.json to. For full list of options, see [Path hints to find specialThemes.json](#path-hints-to-find-special-themes.json). |
+| auto_update      | no       | False          | If you want to enable automatic download of the latest themes every night.                                                                                                                |
+
+---
+**⚠ IMPORTANT NOTE ⚠**
+
+If you are migrating to v2.2.0+ from an earlier version, note that you have to change from the single config line `special_themes_dir: /...` to the `special_themes:`-object.
+
+---
+~~~~yaml
+# Example configuration.yaml entry with special themes, updated every night
+swedish_calendar:
+  special_themes:
+    dir: /config/custom_components/swedish_calendar
+    auto_update: True
+~~~~
+
+#### Path hints to find specialThemes.json
 | HASS set up method | Path                                                                    |
 |--------------------|-------------------------------------------------------------------------|
 | Hassio/HassOS      | `/config/custom_components/swedish_calendar`                            |
 | Manual venv        | `/home/homeassistant/.homeassistant/custom_components/swedish_calendar` |
 
-~~~~yaml
-# Example configuration.yaml entry with special themes
-swedish_calendar:
-  special_themes_dir: /config/custom_components/swedish_calendar
-~~~~
 
 ### Calendar
 | Name              | Required | Default      | Description                                                                                                                   |

--- a/README.md
+++ b/README.md
@@ -66,10 +66,10 @@ swedish_calendar:
 ### Special themes
 Special themes include data about common celebrations in Sweden, like 🍪 Kanelbullens dag or 🦢 Mårtensafton.
 
-| Name             | Required | Default        | Description                                                                                                                                                                               |
-|------------------|----------|----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dir              | no       | *empty string* | The path to the directory where you downloaded the specialThemes.json to. For full list of options, see [Path hints to find specialThemes.json](#path-hints-to-find-special-themes.json). |
-| auto_update      | no       | False          | If you want to enable automatic download of the latest themes every night.                                                                                                                |
+| Name        | Required | Default        | Description                                                                                                                                                                             |
+|-------------|----------|----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| dir         | no       | *empty string* | The path to the directory where you downloaded the specialThemes.json to. For full list of options, see [Path hints to find specialThemes.json](#path-hints-to-find-specialthemesjson). |
+| auto_update | no       | False          | If you want to enable automatic download of the latest themes every night.                                                                                                              |
 
 ---
 **⚠ IMPORTANT NOTE ⚠**

--- a/custom_components/swedish_calendar/__init__.py
+++ b/custom_components/swedish_calendar/__init__.py
@@ -78,15 +78,16 @@ def get_special_themes_config(config: dict) -> SpecialThemesConfig:
     #  Warn and (maybe) migrate old config to new
     if deprecated_themes_path:
         if not new_themes_path:
-            _LOGGER.error('WARNING! Config entry "%s" is deprecated since %s, please migrate to themes schema instead! '
-                          'Using old value for now...',
-                          CONF_SPECIAL_THEMES_DIR,
-                          deprecated_since)
+            _LOGGER.warning(
+                'WARNING! Config entry "%s" is deprecated since %s, please migrate to themes schema instead! '
+                'Using old value for now...',
+                CONF_SPECIAL_THEMES_DIR,
+                deprecated_since)
             new_themes_path = deprecated_themes_path
         else:
-            _LOGGER.error('WARNING! Config entry "%s" is deprecated since %s, please remove from the config!',
-                          CONF_SPECIAL_THEMES_DIR,
-                          deprecated_since)
+            _LOGGER.warning('WARNING! Config entry "%s" is deprecated since %s, please remove from the config!',
+                            CONF_SPECIAL_THEMES_DIR,
+                            deprecated_since)
     if new_themes_path:
         path = os.path.join(new_themes_path, SPECIAL_THEMES_FILE_NAME)
         if not os.path.exists(path):

--- a/custom_components/swedish_calendar/__init__.py
+++ b/custom_components/swedish_calendar/__init__.py
@@ -7,8 +7,8 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.discovery import async_load_platform
 
-from .const import DOMAIN, CONF_SPECIAL_THEMES_DIR, SPECIAL_THEMES_PATH, CONF_EXCLUDE, SENSOR_TYPES, CONF_INCLUDE, \
-    CONF_DAYS_BEFORE_TODAY, CONF_DAYS_AFTER_TODAY, CONF_CALENDAR
+from .const import DOMAIN, CONF_SPECIAL_THEMES_DIR, SPECIAL_THEMES_FILE_NAME, CONF_EXCLUDE, SENSOR_TYPES, CONF_INCLUDE, \
+    CONF_DAYS_BEFORE_TODAY, CONF_DAYS_AFTER_TODAY, CONF_CALENDAR, CONF_AUTO_UPDATE, CONF_DIR, CONF_SPECIAL_THEMES
 from .provider import CalendarDataCoordinator
 from .types import SpecialThemesConfig, CalendarConfig
 
@@ -21,11 +21,21 @@ CALENDAR_SCHEMA = vol.Schema(
     }
 )
 
+THEMES_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_DIR, default=''): cv.string,
+        vol.Optional(CONF_AUTO_UPDATE, default=False): cv.boolean,
+    },
+    extra=vol.ALLOW_EXTRA,
+)
+
 CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN: vol.Schema(
             {
+                # deprecated but hass cant move to an inner object, so we handle everything ourselves
                 vol.Optional(CONF_SPECIAL_THEMES_DIR, default=''): cv.string,
+                vol.Optional(CONF_SPECIAL_THEMES, default={}): THEMES_SCHEMA,
                 vol.Optional(CONF_CALENDAR, default={}): CALENDAR_SCHEMA,
                 vol.Optional(CONF_EXCLUDE, default=[]):
                     vol.All(cv.ensure_list, vol.Length(min=0), [vol.In(SENSOR_TYPES)]),
@@ -61,13 +71,30 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
 
 def get_special_themes_config(config: dict) -> SpecialThemesConfig:
     path = None
-    if config[CONF_SPECIAL_THEMES_DIR]:
-        path = os.path.join(config[CONF_SPECIAL_THEMES_DIR], SPECIAL_THEMES_PATH)
+    deprecated_themes_path: str = config[CONF_SPECIAL_THEMES_DIR]
+    new_themes_path: str = config[CONF_SPECIAL_THEMES][CONF_DIR]
+    deprecated_since = 'v2.2.0'
+
+    #  Warn and (maybe) migrate old config to new
+    if deprecated_themes_path:
+        if not new_themes_path:
+            _LOGGER.error('WARNING! Config entry "%s" is deprecated since %s, please migrate to themes schema instead! '
+                          'Using old value for now...',
+                          CONF_SPECIAL_THEMES_DIR,
+                          deprecated_since)
+            new_themes_path = deprecated_themes_path
+        else:
+            _LOGGER.error('WARNING! Config entry "%s" is deprecated since %s, please remove from the config!',
+                          CONF_SPECIAL_THEMES_DIR,
+                          deprecated_since)
+    if new_themes_path:
+        path = os.path.join(new_themes_path, SPECIAL_THEMES_FILE_NAME)
         if not os.path.exists(path):
             _LOGGER.warning("Special themes is configured but file cannot be found at %s, please check your config",
                             path)
+    auto_update = config[CONF_SPECIAL_THEMES][CONF_AUTO_UPDATE]
 
-    return SpecialThemesConfig(path)
+    return SpecialThemesConfig(path, auto_update)
 
 
 def get_calendar_config(config: dict) -> CalendarConfig:

--- a/custom_components/swedish_calendar/const.py
+++ b/custom_components/swedish_calendar/const.py
@@ -6,9 +6,10 @@ VERSION = '2.1.0'
 
 CONF_CALENDAR = 'calendar_config'
 CONF_SPECIAL_THEMES = 'special_themes'
+CONF_DIR = 'dir'
+CONF_AUTO_UPDATE = 'auto_update'
 CONF_SPECIAL_THEMES_DIR = 'special_themes_dir'
-CONF_SPECIAL_THEMES_AUTO_UPDATE = 'autoupdate'
-SPECIAL_THEMES_PATH = 'specialThemes.json'
+SPECIAL_THEMES_FILE_NAME = 'specialThemes.json'
 
 CONF_ATTRIBUTION = 'Data provided by sholiday.faboul.se'
 CONF_ATTRIBUTION_SPECIAL_THEMES = 'Data provided by https://temadagar.se. For full calendar, ' \

--- a/custom_components/swedish_calendar/types.py
+++ b/custom_components/swedish_calendar/types.py
@@ -21,9 +21,25 @@ class SensorConfig:
 
 
 class SwedishCalendar:
-    def __init__(self, api_data: Optional[ApiData], themes: Optional[ThemeData]):
+    def __init__(self):
+        self._api_data: Optional[ApiData] = None
+        self._themes: Optional[ThemeData] = None
+
+    @staticmethod
+    def from_api_data(api_data: ApiData) -> SwedishCalendar:
+        return SwedishCalendar().with_api_data(api_data)
+
+    @staticmethod
+    def from_themes(themes: ThemeData) -> SwedishCalendar:
+        return SwedishCalendar().with_themes(themes)
+
+    def with_api_data(self, api_data: ApiData) -> SwedishCalendar:
         self._api_data = api_data
+        return self
+
+    def with_themes(self, themes: ThemeData) -> SwedishCalendar:
         self._themes = themes
+        return self
 
     def get_value_by_attribute(self, attr: str) -> Any:
         if attr != 'themes':
@@ -66,8 +82,9 @@ class ThemeData:
 
 
 class SpecialThemesConfig:
-    def __init__(self, path: str):
+    def __init__(self, path: str, auto_update: False):
         self.path = path
+        self.auto_update = auto_update
 
 
 class CalendarConfig:


### PR DESCRIPTION
#13 Opt in to download special themes file

- Update config format so that special themes is an object (now we can add even more config there if needed)
- Log deprecation warnings if using the old config format, but use data from the old format if no new format present
- Add `auto_update` flag
- Update special themes file at midnight from github master branch, but don't update the file at reboot (since that might slow down the system start)